### PR TITLE
Feat/llm txt generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "pulldown-cmark",
  "quick-xml",
  "rayon",
+ "regex",
  "serde",
  "serde_yaml",
  "syntect",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a personal blog and logbook about my journey, dreams, and ideas in compu
 - [x] Add support for llms.txt generation
 - [ ] Enhance cli parametrization and create a common api to read a json config or yml
 - [ ] Too much clone sin rust code, need optimization
+- [ ] Add plugin system to ssg generator
 - [x] Modularize tracking
 - [x] Create a framework to autogenerate the website files
 - [ ] Improve the code for the SSG generator of the blog

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This is a personal blog and logbook about my journey, dreams, and ideas in compu
 
 ## Roadmap
 - [x] Add google tracking
+- [x] Add support for llms.txt generation
+- [ ] Enhance cli parametrization and create a common api to read a json config or yml
+- [ ] Too much clone sin rust code, need optimization
 - [x] Modularize tracking
 - [x] Create a framework to autogenerate the website files
 - [ ] Improve the code for the SSG generator of the blog
@@ -42,5 +45,6 @@ This is a personal blog and logbook about my journey, dreams, and ideas in compu
 - [ ] Does github actions allows us to run only especific jobs in a new pristine run? chances are that not and the way to resolve this is with composition of reusing workflopws
 - [ ] Optimice client routing with service worker cache
 - [ ] Otpimice with idlleCallback the client routing
+- [ ] Document use case of swe agent in mi daily life how I can let do this tasks while designning and learning
 ## License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/crates/ssg-generator-utils/Cargo.toml
+++ b/crates/ssg-generator-utils/Cargo.toml
@@ -12,6 +12,7 @@ minijinja = { version = "2.11.0", features = ["loader"] }
 pulldown-cmark = "0.13.0"
 quick-xml = "0.38.1"
 rayon = "1.10.0"
+regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.34"
 syntect = "5.2.0"

--- a/crates/ssg/src/main.rs
+++ b/crates/ssg/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use clap::Parser;
 use glob::glob;
-use ssg_generator_utils::generate_site;
+use ssg_generator_utils::{generate_site, load_meta};
 use syntect::parsing::SyntaxSet;
 use tailwindcss_oxide::scanner::{Scanner, sources::PublicSourceEntry};
 
@@ -73,6 +73,10 @@ fn main() {
     let templates_path = Path::new("crates/ssg-generator-utils/templates");
     let syntaxes_path = Path::new("crates/ssg-generator-utils/syntaxes");
     let content_index_path = Path::new("crates/ssg-generator-utils/content-index.html");
+    let main_meta_inf = load_meta(&base.join("meta.yml"));
+
+    let llms_title = main_meta_inf.llm_title.as_deref();
+    let llms_description = main_meta_inf.llm_description.as_deref();
 
     if let Err(e) = generate_site(
         md_files,
@@ -82,6 +86,9 @@ fn main() {
         templates_path,
         syntaxes_path,
         content_index_path,
+        Some(true),
+        llms_title,
+        llms_description,
     ) {
         eprintln!("Failed to generate site: {}", e);
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:serve": "cargo build --release && ./target/release/ssg && tsx ./scripts/build.mts && serve dist -p 3001",
+    "build:serve": "cargo run  && tsx ./scripts/build.mts && serve dist -p 3001",
     "build": "tsx ./scripts/build.mts"
   },
   "keywords": [],

--- a/pages/articles-coming-soon/meta.yml
+++ b/pages/articles-coming-soon/meta.yml
@@ -1,0 +1,1 @@
+omit_llm_txt_generation: true

--- a/pages/experiments/meta.yml
+++ b/pages/experiments/meta.yml
@@ -1,0 +1,1 @@
+omit_llm_txt_generation: true

--- a/pages/happy-birthday-Heud/meta.yml
+++ b/pages/happy-birthday-Heud/meta.yml
@@ -1,0 +1,1 @@
+omit_llm_txt_generation: true

--- a/pages/how-I-am-creating-my-blog/index.md
+++ b/pages/how-I-am-creating-my-blog/index.md
@@ -21,6 +21,13 @@ Basically I need some glue code for all of that
 Surely uploading the compiled binary of rust is not actually a good practice, but
 trying to make it run as a script thing is just too slow beacuse we need the compilation process first
 
+<exclude-from-llm-txt>
+Not show in llm txt
+</exclude-from-llm-txt>
+
+<only-in-llm-txt>
+I only be in the copy
+</only-in-llm-txt>
 An idea for that is to publish to github releases. This tool will rarely change so 
 another option could be npm pacakges or the gh registry.
 

--- a/pages/how-I-am-creating-my-blog/meta.yml
+++ b/pages/how-I-am-creating-my-blog/meta.yml
@@ -1,2 +1,4 @@
 title: How I am creating my blog
 extends: base.html
+page_slug: blog-creation-process
+llm_description: LLMs should see this if asked how this blog is constructed

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,79 +1,128 @@
-  <main class="grid gap-8 p-3 sm:p-10 place-content-center">
-    <section class="flex gap-8 justify-center items-center md:p-20 max-w-5xl place-self-center">
-      <div class="hidden md:block w-[200px] grow-1 shrink-0">
-        <img src="./assets/wizard.lulita.webp" alt="a funny dog with clothes and typing in a computer" width="200"
-          class="rounded-2xl" height="200" />
+<main class="grid gap-8 p-3 sm:p-10 place-content-center">
+   <section class="flex gap-8 justify-center items-center md:p-20 max-w-5xl place-self-center">
+      <div class="hidden w-[200px] grow-1 shrink-0">
+         <!-- <img hidden src="./assets/wizard.lulita.webp" alt="a funny dog with clothes and typing in a computer" width="200"
+            class="rounded-2xl" height="200" /> -->
       </div>
       <hgroup class="flex flex-col gap-5 items-center md:items-stretch">
-        <h1
-          class="text-shadow-cyan-300 text-shadow-sm text-center font-extrabold md:text-left text-6xl text-title-primary ">
-          With the Heart of a Computer
-          Wizard</h1>
-        <img aria-hidden="true" class="block md:hidden rounded-2xl" src="./assets/wizard.lulita.webp"
-          alt="a funny dog with clothes and typing in a computer" width="200" height="200" />
-        <h2 class="text-subtitle-primary font-bold text-center md:text-left text-3xl">On my journey, my dreams, and the
-          ideas along the way...
-        </h2>
+         <h1
+            class="text-shadow-cyan-300 text-shadow-sm text-center font-extrabold text-6xl! text-title-primary ">
+            With the Heart of a Computer
+            Wizard
+         </h1>
+         <svg xmlns="http://www.w3.org/2000/svg"
+            width="100%" height="100%" viewBox="0 0 32 16"
+            shape-rendering="crispEdges"
+            class="rounded-2xl"
+          >
+            <rect x="1" y="1" width="11" height="8" fill="#6b6b6b"/>
+            <rect x="2" y="2" width="9" height="6" fill="#081024"/>
+            <rect x="3" y="3" width="1" height="1" fill="#2fe8ff"/>
+            <rect x="5" y="3" width="3" height="1" fill="#2fe8ff"/>
+            <rect x="3" y="5" width="6" height="1" fill="#2fe8ff"/>
+            <rect x="10" y="6" width="1" height="1" fill="#2fe8ff"/>
+            <rect x="1" y="9" width="11" height="1" fill="#2b2b2b"/>
+            <rect x="5" y="10" width="3" height="1" fill="#6b6b6b"/>
+            <rect x="4" y="11" width="5" height="1" fill="#2b2b2b"/>
+            <rect x="1" y="12" width="11" height="2" fill="#8b8b8b"/>
+            <rect x="2" y="12" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="4" y="12" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="6" y="12" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="8" y="12" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="3" y="13" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="5" y="13" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="7" y="13" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="9" y="13" width="1" height="1" fill="#bfbfbf"/>
+            <rect x="12" y="13" width="1" height="1" fill="#2b2b2b"/>
+<rect x="24" y="1" width="1" height="1" fill="#3f0066"/>
+            <rect x="23" y="2" width="3" height="1" fill="#3f0066"/>
+            <rect x="22" y="3" width="5" height="1" fill="#3f0066"/>
+            <rect x="23" y="4" width="3" height="1" fill="#9900cc"/>
+            <rect x="24" y="5" width="1" height="1" fill="#f4c2a1"/>
+            <rect x="23" y="6" width="3" height="1" fill="#f4c2a1"/>
+            <rect x="23" y="7" width="1" height="1" fill="#ffffff"/>
+            <rect x="24" y="7" width="1" height="1" fill="#ffffff"/>
+            <rect x="25" y="7" width="1" height="1" fill="#ffffff"/>
+            <rect x="22" y="8" width="5" height="4" fill="#6a0dad"/>
+            <rect x="22" y="10" width="1" height="2" fill="#9900cc"/>
+            <rect x="26" y="10" width="1" height="2" fill="#3f0066"/>
+            <rect x="27" y="9" width="1" height="1" fill="#6a0dad"/>
+            <rect x="28" y="10" width="1" height="1" fill="#f4c2a1"/>
+            <rect x="29" y="9" width="1" height="5" fill="#8b5a2b"/>
+            <rect x="29" y="8" width="1" height="1" fill="#2fe8ff"/>
+            <rect x="23" y="12" width="1" height="1" fill="#2b2b2b"/>
+            <rect x="25" y="12" width="1" height="1" fill="#2b2b2b"/>
+            <rect x="28" y="7" width="1" height="1" fill="#2fe8ff"/>
+            <rect x="30" y="7" width="1" height="1" fill="#2fe8ff"/>
+            <rect x="1" y="1" width="1" height="1" fill="#000000" opacity="0.06"/>
+            <rect x="11" y="1" width="1" height="1" fill="#000000" opacity="0.06"/>
+            <rect x="18" y="8" width="1" height="1" fill="#000000" opacity="0.06"/>
+         </svg>
+         <!-- <img hidden aria-hidden="true" class="block md:hidden rounded-2xl" src="./assets/wizard.lulita.webp"
+            alt="a funny dog with clothes and typing in a computer" width="200" height="200" /> -->
+         <h2 class="text-subtitle-primary font-bold text-center text-3xl!">On my journey, my dreams, and the
+            ideas along the way...
+         </h2>
       </hgroup>
-    </section>
-    <section class="max-w-5xl grid gap-6">
+   </section>
+   <section class="max-w-5xl grid gap-6">
       <p>For the content index page listing the articles you can click <a data-client-navigation="hover"
-          href="./content-index">here</a></p>
+         href="./content-index">here</a></p>
       <p>
-        Long story short: I think I'm burned out — for many reasons.
-        But it's not all shadows. Lately, I've met wonderful people who encourage, inspire, and remind me not to give
-        up.
+         Long story short: I think I'm burned out — for many reasons.
+         But it's not all shadows. Lately, I've met wonderful people who encourage, inspire, and remind me not to give
+         up.
       </p>
       <p>
-        Their inspiration has unearthed an old dream I had buried:
-        I want to become a <a href="https://jvns.ca/blog/so-you-want-to-be-a-wizard/">Computer Wizard</a>.
+         Their inspiration has unearthed an old dream I had buried:
+         I want to become a <a href="https://jvns.ca/blog/so-you-want-to-be-a-wizard/">Computer Wizard</a>.
       </p>
       <p>
-        So, this little public corner of the web will be my logbook — a place to share my journey and my ideas.
-        I love reinventing the wheel, exploring performance, and navigating tricky trade-offs just for the joy of
-        discovery (even the <a href="https://github.com/Shadowrunner8095/my-blog">source code</a> of this blog does not
-        use a bundler or any modern page builder, just for the sake of learning).
+         So, this little public corner of the web will be my logbook — a place to share my journey and my ideas.
+         I love reinventing the wheel, exploring performance, and navigating tricky trade-offs just for the joy of
+         discovery (even the <a href="https://github.com/Shadowrunner8095/my-blog">source code</a> of this blog does not
+         use a bundler or any modern page builder, just for the sake of learning).
       </p>
       <p>
-        I know I still have a lot to learn, and I hope this growing collection will stand as a record of my path.
-        So… <em>per aspera ad astra</em>, friends.
-        (And yes — the image is AI-generated; otherwise, that monitor wouldn’t be in such a strange position.)
+         I know I still have a lot to learn, and I hope this growing collection will stand as a record of my path.
+         So… <em>per aspera ad astra</em>, friends.
+         (And yes — the image is AI-generated; otherwise, that monitor wouldn’t be in such a strange position.)
       </p>
-    </section>
-    <section class="max-w-5xl grid gap-6">
+   </section>
+   <section class="max-w-5xl grid gap-6">
       <h3 class="text-subtitle-primary font-bold text-3xl">Who am I?</h3>
       <p>
-        And… why am I? Good question. I'll update my social links soon.
-        For now, you can find me on <a href="https://github.com/shadowRunner8095/my-blog">GitHub</a>
-        and <a href="https://medium.com/@shadowrunner8095">Medium</a>. Let's see where this road takes us.
+         And… why am I? Good question. I'll update my social links soon.
+         For now, you can find me on <a href="https://github.com/shadowRunner8095/my-blog">GitHub</a>
+         and <a href="https://medium.com/@shadowrunner8095">Medium</a>. Let's see where this road takes us.
       </p>
-    </section>
-    <section class="max-w-5xl grid gap-6">
+   </section>
+   <section class="max-w-5xl grid gap-6">
       <h3 class="text-subtitle-primary font-bold text-3xl">FAQ</h3>
       <div class="grid gap-3">
-        <h4 class="font-bold">
-          Your GitHub is empty
-        </h4>
-        <p>
-          It's brand new.
-        </p>
+         <h4 class="font-bold">
+            Your GitHub is empty
+         </h4>
+         <p>
+            It's brand new.
+         </p>
       </div>
       <div class="grid gap-3">
-        <h4 class="font-bold">
-          I have checked this repo, what is with the .devcontainer?
-        </h4>
-        <p>
-          Some articles are on the way to explain that. I'm already working on a draft, but mainly it's because I wanted
-          a secure local environment to work in.
-        </p>
+         <h4 class="font-bold">
+            I have checked this repo, what is with the .devcontainer?
+         </h4>
+         <p>
+            Some articles are on the way to explain that. I'm already working on a draft, but mainly it's because I wanted
+            a secure local environment to work in.
+         </p>
       </div>
       <div class="grid gap-3">
-        <h4 class="font-bold">
-          Why not Rspress, Docusaurus, MkDocs, etc.?
-        </h4>
-        <p>
-          I like to complicate my life reinventing the wheel in order to learn more in my "free time."
-        </p>
+         <h4 class="font-bold">
+            Why not Rspress, Docusaurus, MkDocs, etc.?
+         </h4>
+         <p>
+            I like to complicate my life reinventing the wheel in order to learn more in my "free time."
+         </p>
       </div>
-    </section>
-  </main>
+   </section>
+</main>

--- a/pages/meta.yml
+++ b/pages/meta.yml
@@ -1,0 +1,3 @@
+omit_llm_txt_generation: true
+llm_description: "This is my personal blog, it has content about tech, computer science and programming"
+llm_title: "My path to become a Wizard Computer"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Generate llms.txt and optional LLM-friendly Markdown copies per page using include/exclude tags.
  - Added a content index page and enhanced sitemap with domain-aware links.
  - Support slug-based page URLs.
- Style
  - Refreshed home hero: replaced image with inline SVG and centered heading typography.
- Documentation
  - Expanded README roadmap with new items.
- Chores
  - Simplified local build-and-serve script (single cargo run followed by frontend build and serve).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->